### PR TITLE
Use autocommit_before_ddl

### DIFF
--- a/app.js
+++ b/app.js
@@ -129,7 +129,12 @@ async function deleteAccounts(client, transaction) {
 
 // Run the transactions in the connection pool
 (async () => {
-  // Initialize table in transaction retry wrapper
+  // Prevent knex migration framework from running
+  // schema changes in a transaction
+  await client.raw("SET autocommit_before_ddl = true");
+
+  // Initialize table in without using a transaction,
+  // since it involves schema changes.
   console.log("Initializing accounts table...");
   await initTable(client);
 

--- a/app.js
+++ b/app.js
@@ -131,7 +131,7 @@ async function deleteAccounts(client, transaction) {
 (async () => {
   // Initialize table in transaction retry wrapper
   console.log("Initializing accounts table...");
-  await retryTxn(0, 15, client, initTable);
+  await initTable(client);
 
   // Transfer funds in transaction retry wrapper
   console.log("Transferring funds...");


### PR DESCRIPTION
### Revert "Add txn retry wrapper to init step"

This reverts commit 142ebc1.

### Use autocommit_before_ddl

This prevents the knex migrations framework from running DDL statements
in a transaction, which can cause unexpected retry errors.

fixes https://github.com/cockroachlabs/support/issues/3117